### PR TITLE
rubocop: Enable AmbiguousBlockAssociation

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -17,10 +17,6 @@ AllCops:
 Rails:
   Enabled: true
 
-# TODO: Enable after the issue is fixed: https://github.com/bbatsov/rubocop/pull/4237
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
-
 # Top-level class documentation comment is unnecessary in most cases
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
The `Lint/AmbiguousBlockAssociation` rule had a bug but its fix was released at [v0.49.0](https://github.com/bbatsov/rubocop/releases/tag/v0.49.0). 

