### PR TITLE
rubocop: ignore `config/**/*` without `config/routes.rb`

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -4,12 +4,12 @@ AllCops:
   Exclude:
     - "bin/**/*"
     - "db/schema.rb"
-    - "config/**/*"
     - "log/**/*"
     - "public/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
     - "node_modules/**/*"
+    - !ruby/regexp /config\/(?!routes\.rb$).*/
   UseCache: true
   DisplayCopNames: true
   DisplayStyleGuide: true


### PR DESCRIPTION
@interfirm/dev Please /review and give any feedbacks 🙇 

See <http://rubocop.readthedocs.io/en/latest/configuration/#includingexcluding-files>.