### PR TITLE
feat(rubocop): add `bin/*` files to target

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -2,7 +2,6 @@ AllCops:
   TargetRubyVersion: 2.3
   TargetRailsVersion: 5.0
   Exclude:
-    - "bin/**/*"
     - "db/schema.rb"
     - "log/**/*"
     - "public/**/*"


### PR DESCRIPTION
`bin/setup` などのRubyスクリプトも、Rubocopチェック対象にする案です。
`rubocop --auto-correct` で簡単に修正できるので、対象に入れておいても良いかなと考えました。

@interfirm/dev Please /review and any feedbacks! 🙇 