### PR TITLE
Update Slack token for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ after_failure:
 
 notifications:
   email: false
-  slack: interfirm:L2WhP1umnVtkeYcz6Uedkocs#developer
+  slack: interfirm:nQ2iFItAwPADePQlPgmcVE2D#developer
 
 deploy:
   provider: npm


### PR DESCRIPTION
connect to interfirm/etc#157

SlackのIntegration設定を`interfirm`アカウントで作り直したので、Tokenが変わりました。
(No reviews needed)