### PR TITLE
feat: uninstall `fs-extra` because of `fs.copyFileSync` standard API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const fs = require("fs")
-const fse = require("fs-extra")
 const path = require("path")
 const configFiles = require("./config-files")
 
@@ -50,7 +49,7 @@ const syncConfigFiles = (userRepoDir, userConfig, allConfigs) => {
     const destPath = path.join(userRepoDir, destFile || defaultPath)
 
     console.log(`Sync config: ${destPath}`)
-    fse.copySync(srcPath, destPath)
+    fs.copyFileSync(srcPath, destPath)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "homepage": "https://github.com/interfirm/configs",
   "bugs": "https://github.com/interfirm/configs/issues",
   "license": "MIT",
+  "engines": {
+    "node": ">=8.5"
+  },
   "bin": {
     "configs-sync": "bin/configs-sync"
   },
@@ -28,9 +31,7 @@
       "git add"
     ]
   },
-  "dependencies": {
-    "fs-extra": "*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "*",
     "@commitlint/config-angular": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,14 +760,6 @@ franc@^2.0.0:
   dependencies:
     trigram-utils "^0.1.0"
 
-fs-extra@*:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -832,7 +824,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1086,12 +1078,6 @@ json-stable-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -1936,10 +1922,6 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
-
-universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
`fs.copyFileSync` was introduced since Node 8.5.0.

For details, see https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_flags