### PR TITLE
feat(rubocop): use `.ruby-version` for `TargetRubyVersion` by default

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.4
   TargetRailsVersion: 5.1
   Exclude:
     - "db/schema.rb"


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/blob/56e5036924cf9498ba0aee4fea11cae7844d6ab7/config/default.yml#L117