### PR TITLE
feat(rubocop): add `staging` to `Rails/UnknownEnv` cop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -15,6 +15,13 @@ AllCops:
 Rails:
   Enabled: true
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+    - staging
+
 # Top-level class documentation comment is unnecessary in most cases
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
connect to #71 

The `Rails/UnknownEnv` feature was introduced in [RuboCop v0.51.0](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0510-2017-10-18).