### PR TITLE
chore: fix `@commitlint/config-angular` version to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "*",
-    "@commitlint/config-angular": "*",
+    "@commitlint/config-angular": "4",
     "eslint": "*",
     "eslint-config-interfirm": "*",
     "husky": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,7 +13,7 @@
     lodash "^4.17.4"
     meow "^3.7.0"
 
-"@commitlint/config-angular@*":
+"@commitlint/config-angular@4":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@commitlint/config-angular/-/config-angular-4.3.0.tgz#c05fd9c30f8dd0c32c549bb1587e8af2c2769765"
 


### PR DESCRIPTION
From version 5, `chore` type is deleted.

See https://github.com/marionebl/commitlint/issues/146