### PR TITLE
行数などの一律チェックを無効化・緩和する

### DIFF
--- a/templates/.codeclimate.yml
+++ b/templates/.codeclimate.yml
@@ -1,5 +1,5 @@
----
-engines:
+version: "2"
+plugins:
   brakeman:
     enabled: true
   bundler-audit:
@@ -15,19 +15,7 @@ engines:
       - ruby
   fixme:
     enabled: true
-ratings:
-  paths:
-  - Gemfile.lock
-  - "**.erb"
-  - "**.haml"
-  - "**.rb"
-  - "**.rhtml"
-  - "**.slim"
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"
-exclude_paths:
+exclude_patterns:
 - config/**/*
 - db/**/*
 - vendor/**/*

--- a/templates/.codeclimate.yml
+++ b/templates/.codeclimate.yml
@@ -1,4 +1,15 @@
 version: "2"
+checks:
+  argument-count:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  return-statements:
+    enabled: false
 plugins:
   brakeman:
     enabled: true

--- a/templates/.codeclimate.yml
+++ b/templates/.codeclimate.yml
@@ -23,7 +23,8 @@ plugins:
     enabled: true
     config:
       languages:
-      - ruby
+        ruby:
+          mass_threshold: 30
   fixme:
     enabled: true
 exclude_patterns:

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -55,7 +55,7 @@ Metrics/LineLength:
 
 Metrics/ClassLength:
   Enabled: true
-  Max: 100
+  Max: 200
   Exclude:
     - "test/**/*"
     - "spec/**/*"
@@ -63,7 +63,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Enabled: true
   CountComments: false
-  Max: 20
+  Max: 50
   Exclude:
     - "test/**/*"
     - "spec/**/*"


### PR DESCRIPTION
connect to interfirm/etc#220

CodeClimate (と Rubocop) の設定を一部緩和し、メソッド行数などの静的な上限設定を緩めました。

- [CodeClimate - Advanced Configuration](https://docs.codeclimate.com/docs/advanced-configuration#section-default-check-configurations)