### PR TITLE
feat(rubocop): Loosen Naming/UncommunicativeMethodParamName cop

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -85,3 +85,7 @@ Metrics/AbcSize:
   Exclude:
     - "test/**/*"
     - "spec/**/*"
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: true
+  MinNameLength: 1


### PR DESCRIPTION
デフォルトでは仮引数名が3文字未満だと uncommunicative と判定されるが、短い名前がわかりにくいとは必ずしも限らないと思う。

例えば以下のメソッド例は全て3文字未満の引数を含むが、いずれも変数名の意味自体は自明だと感じる
(特にそのメソッドを持つクラスやモジュールの文脈と合わせて考えれば)。

```ruby
def take_range(from, to); end

def respond(ok:, message:); end

def find(id); end

def trim_spaces(s); end

def search(q); end
```