### PR TITLE
Update RuboCop config

### DIFF
--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -63,14 +63,14 @@ Metrics/LineLength:
 
 Metrics/ClassLength:
   Enabled: true
-  Max: 200
+  Max: 400
   Exclude:
     - "test/**/*"
     - "spec/**/*"
 
 Metrics/ModuleLength:
   Enabled: true
-  Max: 200
+  Max: 400
   Exclude:
     - "test/**/*"
     - "spec/**/*"
@@ -92,10 +92,14 @@ Metrics/BlockLength:
 
 Metrics/AbcSize:
   Enabled: true
-  Max: 25
+  Max: 50
   Exclude:
     - "test/**/*"
     - "spec/**/*"
+
+Metrics/CyclomaticComplexity:
+  Enabled: true
+  Max: 24
 
 Naming/UncommunicativeMethodParamName:
   Enabled: true

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -49,6 +49,10 @@ Layout/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
 
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "vendor/**/*"
     - "node_modules/**/*"
     - !ruby/regexp /config\/(?!routes\.rb$).*/
+    - !ruby/regexp /db\/migrate\/.+\/.*/
   UseCache: true
   DisplayCopNames: true
   DisplayStyleGuide: true


### PR DESCRIPTION
- `Metrics/CyclomaticComplexity` などの静的な上限設定はデフォルトだと厳しすぎる。可読性に問題なくても引っかかるので上限を大幅に上げる。
- メソッドチェーンのインデント規約を改善する。
- `db/migrate/2015` などサブディレクトリ内にあるマイグレーションファイルは無視するようにする。