### PR TITLE
chore: Specify lodash version for security update

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "eslint-config-prettier": "^3",
     "husky": "*",
     "lint-staged": "*"
+  },
+  "resolutions": {
+    "**/lodash": "4.17.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,18 +1452,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.5:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-
-lodash@^4.17.11, lodash@^4.2.1:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+lodash@4.17.11, lodash@4.17.13, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- https://yarnpkg.com/lang/en/docs/selective-version-resolutions/

GitHub の Security アラートより。しかしこの警告ページへのパーマネントリンク欲しい。。

<img width="608" alt="Alerts_·_interfirm_configs" src="https://user-images.githubusercontent.com/12684251/61029689-8dee5580-a3f6-11e9-8e9e-5325830d1ac9.png">
